### PR TITLE
Defer font loading using font-display property

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link href="https://fonts.googleapis.com/css?family=Ubuntu" rel="stylesheet">
     <title>MattBlock</title>
   </head>
   <body>

--- a/src/index.scss
+++ b/src/index.scss
@@ -8,6 +8,7 @@
 @import "./style/colors.scss";
 @import "./style/typography.scss";
 @import "./style/buttons.scss";
+@import "./style/fonts.scss";
 
 body {
   margin: 0;

--- a/src/style/fonts.scss
+++ b/src/style/fonts.scss
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) 2018-present, Matei Bogdan Radu <matei.radu.92@gmail.com>
+ *
+ * This source code is licensed under the MIT license found in the LICENSE
+ * file in the root directory of this source tree.
+ */
+
+@font-face {
+  font-family: "Ubuntu";
+  font-display: swap;
+  src: local("Ubuntu"), url(https://fonts.gstatic.com/s/ubuntu/v12/4iCs6KVjbNBYlgoKfw72nU6AFw.woff2) format('woff2');
+} 


### PR DESCRIPTION
To reduce FMP, the blocking font link in the document head is removed.
Instead, the font is now loaded from CSS using the `font-display`
property to defer loading.